### PR TITLE
Implicitly converts ASCII bytestrings to unicode

### DIFF
--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -231,6 +231,28 @@ class Test_accessfield(unittest.TestCase):
         self.assertEqual(obj.f, '4')
 
 
+class Test_stringconversion(unittest.TestCase):
+    """Specific tests for Python to Java String conversions.
+    """
+    def test_unicode(self):
+        String = _pyjava.getclass('java/lang/String')
+        s = String(u'lala')
+        self.assertEqual(s.length(), 4)
+        t = String(u'something\u263Aelse')
+        self.assertEqual(t.length(), 14)
+        u = String(u'embedded\0zero')
+        self.assertEqual(u.length(), 13)
+
+    def test_str(self):
+        String = _pyjava.getclass('java/lang/String')
+        s = String(b'lol') # Implicit conversion for ASCII
+        self.assertEqual(s.length(), 3)
+        with self.assertRaises(_pyjava.NoMatchingOverload):
+            t = String(b'r\xE9mi') # FIXME : exception is not very explicit
+        u = String('embedded\0zero')
+        self.assertEqual(u.length(), 13)
+
+
 class Test_conversions(unittest.TestCase):
     """Big set of method calls to cover the conversions.
     """


### PR DESCRIPTION
I'm not sure about this. #python advised me against it.

In any case, if the str object is not decodable using ASCII, the overload will be ignored, so if nothing else matches NoMatchingOverload will be raised (instead of UnicodeDecodeError).

```
18:20 < Yhg1s> IF the user got it wrong, tell them. Don't try to cover it up for them.
18:20 < Remram> it's what I'm doing right now
18:20 < Remram> but really this should accept str literals
18:20 < Remram> I think
18:20 < Yhg1s> Remram: no, it really shouldn't.
18:21 < Remram> right now String(u'smthg') works and String('smthg') raises NoMatchingOverload
18:21 < Yhg1s> Remram: Java strings are unicode.  Do yourself a favour and don't try to convert silently from bytestrings.
18:21 < Remram> do you think I shouldn't try to fix it?
18:21 < o11c> Remram: good
18:21 < Yhg1s> Remram: you may want to make the errormessage clearer, but I don't recommend trying to make it work, no.
```
